### PR TITLE
[doc] Fix example for auto-buffer-modes

### DIFF
--- a/docs/user_configuration.rst
+++ b/docs/user_configuration.rst
@@ -118,7 +118,6 @@ Example:
 
 .. code-block:: python
 
-   import re
    from webmacs import variables
 
    variables.set("auto-buffer-modes", [

--- a/docs/user_configuration.rst
+++ b/docs/user_configuration.rst
@@ -123,7 +123,7 @@ Example:
 
    variables.set("auto-buffer-modes", [
       (".*www.gnu.org.*", "no-keybindings"),
-      (re.compile("https://mail.google.com/.*"), "no-keybindings")
+      ("https://mail.google.com/.*", "no-keybindings")
   ])
 
 Binding keys


### PR DESCRIPTION
Hello,

From my observations, this example in the documentation is not valid, and leads to the stack trace below. 
Suggest to replace with a simple string?


    Traceback (most recent call last):
  File "~/.webmacs/init/__init__.py", line 16, in init
    g, "no-keybindings")])
  File "~/git_repos/www/webmacs/webmacs/variables.py", line 261, in set
    get_variable(name).set_value(value)
  File "~/git_repos/www/webmacs/webmacs/variables.py", line 44, in set_value
    self.validate(value)
  File "~/git_repos/www/webmacs/webmacs/variables.py", line 32, in validate
    self.type.validate(value)
  File "~/git_repos/www/webmacs/webmacs/variables.py", line 165, in validate
    % (i, exc)) from None
webmacs.variables.VariableConditionError: List at position 1: Tuple at position 0: Must be a string
