### PR TITLE
Doc

### DIFF
--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -13,7 +13,7 @@ It is possible to manage multiple :term:`views` in a webmacs window:
 
 - :key:`C-x 2` split the current view in two horizontally.
 - :key:`C-x 3` split the current view in two vertically.
-- :key:`C-x o` navigates in current window views.
+- :key:`C-x o` navigate in current window views.
 - :key:`C-x 0` close the current view.
 - :key:`C-x 1` maximize the current view, closing every other view.
 
@@ -40,7 +40,7 @@ useful for copying text inside a web page without using the mouse.
 
 It is enabled by pressing :key:`C (webbuffer)`.
 
-Then you can navigate using arrow keys or standard emacs bindings:
+Then you can navigate using arrow keys or standard Emacs bindings:
 
 - :key:`C-n` to go to the next line.
 - :key:`C-p` to go to the previous line.
@@ -70,8 +70,8 @@ You can select some text and copy it using:
 Bookmarks
 *********
 
-Bookmarks are like a dictionary of urls. Each bookmark must have a unique name.
-Bookmarks are stored in the profile, and so are persistent across sessions.
+Bookmarks are like a dictionary of URLs. Each bookmark must have a unique name.
+Bookmarks are stored in the profile, and hence are persistent across sessions.
 
 It is possible to manage bookmarks using:
 
@@ -80,5 +80,5 @@ It is possible to manage bookmarks using:
 
 When in the bookmark list, you can:
 
-- :key:`Return (bookmarks-list)` to open the bookmark url in the current buffer
+- :key:`Return (bookmarks-list)` to open the bookmark URL in the current buffer
 - :key:`C-k (bookmarks-list)` to remove the highlighted bookmark.

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -233,7 +233,7 @@ either **download** or **open** it.
 - **download** will start downloading, and save the file to your hard drive.
 - **open** will download to a temporary directory, then open the file with the given
   command. A list of available commands is shown in the minibuffer completion
-list. Note that when the command exits, the file will be automatically deleted
+  list. Note that when the command exits, the file will be automatically deleted
   from your hard drive.
 
   .. note::

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -4,15 +4,15 @@ Basic usage
 Don't panic
 ***********
 
-When you are stuck in some interactive :term:`command` or text field and you are
-unsure what to do, press **C-g**. This :term:`key binding` usually let you get
+When you are stuck in some interactive :term:`command` or text field, and you
+are unsure what to do, press **C-g**. This :term:`key binding` usually lets you
 out of the current action - you may have to press it more than once. **C-g** is
 the universal *get me out of there* command.
 
 .. note::
 
-  Usually pressing **C-g** enough let you focus on the current :term:`web
-  buffer` and so activate the :keymap:`webbuffer` :term:`keymap`.
+  Usually, pressing **C-g** enough times lets you focus on the current
+  :term:`web buffer`, and so activates the :keymap:`webbuffer` :term:`keymap`.
 
 
 .. current-keymap:: global
@@ -22,7 +22,7 @@ Running a command using its name
 ********************************
 
 It is always possible to run a :term:`command` using its name. Some commands
-does not have default :term:`key bindings` and so requires to be called this
+does not have default :term:`key binding`, and requires to be called this
 way. To call a command using its name, use the :key:`M-x` keybinding, then
 select in the list (or type) the command you want to run, followed by **Return**
 (the Enter key).
@@ -34,25 +34,25 @@ toolbar.
 Live documentation
 ******************
 
-webmacs is self-documenting. You can have access to it easily by running the
-following commands:
+webmacs is self-documenting. You can easily access the documentation by running
+the following commands:
 
 - :cmd:`describe-commands` to see all available commands.
-- :cmd:`describe-command` (bound to :key:`C-h c`) to choose one command and get
+- :cmd:`describe-command` (bound to :key:`C-h c`) to choose one command, and get
   a detailed description.
 - :cmd:`describe-variables` to see all the available :term:`variables`.
 - :cmd:`describe-variable` (bound to :key:`C-h v`) to choose one variable and
   get a detailed description.
 - :cmd:`describe-key` (bound to :key:`C-h k`) to discover what a key binding
   would trigger.
-- :cmd:`describe-bindings` to see the list of every keymaps, with the bindings
+  - :cmd:`describe-bindings` to see the list of all keymaps, with the bindings
   and commands they contain.
 
 
 .. note::
 
-  Self-documentation is super useful for many things. If you want for example to
-  define a custom binding for a command but you don't know its name, you can
+  Self-documentation is super useful for many things. If you want, for example,
+  to define a custom binding for a command, but don't know its name, you can
   always use :key:`C-h k` to help you.
 
   Also, do not hesitate to use :key:`C-h v` to see the description of a
@@ -65,12 +65,12 @@ following commands:
 Visiting urls
 *************
 
-An easy way to go to a new url is to type :key:`g`. This calls the :cmd:`go-to`
-command, that lets you type an url or a :term:`webjump`. Pressing **Return**
+An easy way to go to a new URL is to type :key:`g`. This calls the :cmd:`go-to`
+command, that lets you type a URL or a :term:`webjump`. Pressing **Return**
 will then open it in the current web buffer.
 
 For example, try typing: **g g<tab> webmacs <Return>**. This should open a new
-google page with the query webmacs.
+Google page with the query 'webmacs'.
 
 .. important::
 
@@ -83,7 +83,7 @@ Link hinting
 ************
 
 Link hinting is used to navigate through visible links of the current web
-buffer's page using the keyboard only.
+buffer's page, using the keyboard only.
 
 Press :key:`f`. You should see the :term:`minibuffer` right label displaying
 that you are in the :keymap:`hint` keymap, and the links on the page
@@ -102,24 +102,24 @@ fuzzy matching against the link's texts. It is also possible to directly type
 the number of the link to activate it, and to cycle the visible hints (next,
 previous) to change the active hint.
 
-Keybindings are as follow:
+Keybindings are as follows:
 
 - :key:`C-n` activate next visible hint
 - :key:`C-p` activate previous visible hint
 
-Note to validate hinting, :key:`Return` has to be pressed.
+Note that to validate hinting, :key:`Return` has to be pressed.
 
 alphabet
 --------
 
-This is the method used by default in vimium for example. There is no active
-hint, and to each link some characters are associated: there must be entered all
+This is the method used by default in vimium, for example. There is no active
+hint, and each link is associated with some characters: they must all be entered
 to validate hinting.
 
-Note usually the home row on the keyboard is used to pick up the characters
-randomly. This is configured with the :term:`variable`
+Note that the hinting characters are usually randomly picked up from the home
+row of the keyboard. This behavior is configured with the :term:`variable`
 :var:`hint-alphabet-characters`, defaulting to the home row characters of a
-qwerty keyboard.
+QWERTY keyboard.
 
 
 .. current-keymap:: webbuffer
@@ -133,20 +133,20 @@ Managing buffers
 You can switch to a buffer using :key:`C-x b (global)`, which opens a list on
 top of the :term:`minibuffer`. Select the buffer you want to switch to by
 fuzzy-matching text of the url or title page, or just use the arrow keys (or
-better, standard emacs bindings such as **C-n**, **C-p**, **C-v**, **M-v**, etc)
-and validate with **Return**.
+better, standard Emacs bindings such as **C-n**, **C-p**, **C-v**, **M-v**,
+etc). Finally, validate with **Return**.
 
 .. important::
 
-  Most of the lists displayed in the :term:`minibuffer` works in the same way
+  Most of the lists displayed in the :term:`minibuffer` work in this same way,
   and have the same basic bindings.
 
 The command is called :cmd:`switch-recent-buffer`.
 
 .. note::
 
-  The above command order the buffers so the most recently used is on top. If
-  you want the buffers to be ordeded by their numbers, you can call the
+  The above command orders the buffers so that the most recently used is on top.
+  If you want the buffers to be ordeded by their number, you can call the
   command :cmd:`switch-buffer`.
 
 
@@ -156,7 +156,7 @@ You can also navigate to the next or previous buffer by using respectively
 
 A buffer can be closed by just pressing :key:`q`. When you are running
 :cmd:`switch-buffer` or :cmd:`switch-recent-buffer`, pressing :key:`C-k
-(buffer-list)` will also kills the buffer currently highlighted in the list.
+(buffer-list)` will also kill the buffer currently highlighted in the list.
 
 
 .. important::
@@ -170,32 +170,32 @@ Navigating through buffer history
 
 - :key:`B` goes backward in the buffer history
 - :key:`F` goes forward in the buffer history
-- :key:`b` shows current buffer's history as a list in the :term:`minibuffer`
-  and allows to navigate in there easily.
+- :key:`b` shows the current buffer's history as a list in the :term:`minibuffer`,
+and allows to easily navigate it.
 
 
 Navigating through global history
 *********************************
 
-Type :key:`h` to display a list of every visited urls (those are saved in a
+Type :key:`h` to display a list of every visited URL (these are saved in a
 database file and are persistent in your profile). Select one to open it in the
 current buffer.
 
 .. note::
 
-  Use **C-u** before :key:`h` to open the url in a new buffer.
+  Use **C-u** before :key:`h` to open the URL in a new buffer.
 
 
 Scrolling in current web buffer
 *******************************
 
-- :key:`C-n` or :key:`n` scroll the current buffer down a bit.
-- :key:`C-p` or :key:`p` scroll the current buffer up a bit.
-- :key:`C-b` scroll the current buffer left a bit.
-- :key:`C-f` scroll the current buffer right a bit.
+- :key:`C-n` or :key:`n` scrolls the current buffer down a bit.
+- :key:`C-p` or :key:`p` scrolls the current buffer up a bit.
+- :key:`C-b` scrolls the current buffer left a bit.
+- :key:`C-f` scrolls the current buffer right a bit.
 
-- :key:`C-v` scroll the current buffer down for one visible page.
-- :key:`M-v` scroll the current buffer up for one visible page.
+- :key:`C-v` scrolls the current buffer down for one visible page.
+- :key:`M-v` scrolls the current buffer up for one visible page.
 
 - :key:`M-<` lets you go to the top of the page.
 - :key:`M->` lets you go to the bottom of the page.
@@ -216,7 +216,7 @@ to the previous match.
 Copying links
 *************
 
-- :key:`c u` to copy the url of the current buffer.
+- :key:`c u` to copy the URL of the current buffer.
 - :key:`c l` to copy a visible link in the buffer (by :term:`hinting`).
 - :key:`c c` to copy the currently selected link.
 - :key:`c t` to copy the current buffer page title.
@@ -225,21 +225,21 @@ Copying links
 Downloading
 ***********
 
-A download can be started by clicking on a link or button or :term:`hinting`.
+A download can be started by clicking a link or button or :term:`hinting`.
 
 When a download is about to be started, the :term:`minibuffer` will propose to
 either **download** or **open** it.
 
-- **download** will start downloading, and save the file in your hard drive.
-- **open** will temporarily download, then will open the file with the given
+- **download** will start downloading, and save the file to your hard drive.
+- **open** will download to a temporary directory, then open the file with the given
   command. A list of available commands is shown in the minibuffer completion
-  list. Note when the command will exit, the file will be automatically deleted
+list. Note that when the command exits, the file will be automatically deleted
   from your hard drive.
 
   .. note::
 
-    open is useful for viewing pdf files for example, as you can use your
-    preferred pdf file viewer to read it.
+    open is useful for viewing PDF files for example, as you can use your
+     favourite PDF file viewer to read it.
 
 The list of downloads can be accessed using the :cmd:`downloads` command.
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -170,8 +170,8 @@ Navigating through buffer history
 
 - :key:`B` goes backward in the buffer history
 - :key:`F` goes forward in the buffer history
-- :key:`b` shows the current buffer's history as a list in the :term:`minibuffer`,
-and allows to easily navigate it.
+- :key:`b` shows the current buffer's history as a list in the
+  :term:`minibuffer`, and allows to easily navigate it.
 
 
 Navigating through global history

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,7 +1,7 @@
 Concepts
 ========
 
-Please be sure to understand the following basic webmacs concepts before going
+Please make sure to understand the following basic webmacs concepts before
 further reading the documentation.
 
 
@@ -10,14 +10,15 @@ further reading the documentation.
 Commands, key bindings and keymaps
 **********************************
 
-Those are quite similar to the definitions found in the emacs manual.
+These are quite similar to the definitions found in the Emacs manual.
 
-- A :term:`command` is a named action doable in the browser. For example
-  :cmd:`follow` is the command that allow to start hinting links to navigate.
+- A :term:`command` is a named action which can be done in the browser. For
+  example, :cmd:`follow` is the command that allows to start hinting links to
+  navigate.
 
 - A :term:`key binding` is a combination of key presses used to trigger commands.
-  Key bindings are represented as in emacs, for example **C-x C-b** means
-  holding the Control key while pressing x, then b on the keyboard.
+  Key bindings are represented as in Emacs, for example **C-x C-b** means
+  "holding the Control key while pressing x, then b on the keyboard."
 
   .. note::
 
@@ -25,20 +26,21 @@ Those are quite similar to the definitions found in the emacs manual.
 
     - **C** represents the Control key.
     - **M** represents the Alt key.
-    - **S** represents the Super key (often called the window key)
+    - **S** represents the Super key (often called the Windows key)
 
   .. note::
 
     .. current-keymap:: webbuffer
 
-    A key binding can be a single key press too. For example pressing :key:`f`
+    A key binding can also be a single key press. For example, pressing :key:`f`
     while in the :keymap:`webbuffer` keymap will trigger the :cmd:`follow`
     command.
 
 - A :term:`keymap` is an object holding a mapping between key bindings and
-  commands, so that a command can be triggered by pressing keyboard keys. There
-  is one global keymap, and one active local keymap usually activated at the
-  same time - the local keymap changes interactively depending on the context.
+  commands, so that a command can be triggered by pressing keyboard keys.
+  Usually, there is one global keymap, and one active local keymap activated
+  at the same time - the local keymap changes interactively depending on the
+  context.
 
   Some important keymaps:
 
@@ -49,12 +51,13 @@ Those are quite similar to the definitions found in the emacs manual.
 Web buffers
 ***********
 
-A :term:`web buffer` is like an emacs buffer, but for a web page. Buffers are
-like tabs in other browsers, except that they are not bound to any view or
-window.
+A :term:`web buffer` is like an Emacs buffer, but applying to a Web page.
+Buffers are like tabs in other browsers, except that they are not bound to
+any view or window.
 
 Windows, views
 **************
 
-Unlike the terminology in emacs, a window is a what we nowadays usually call a
-window and :term:`views` (sometimes called frames) are contained in windows.
+Differing from Emacs terminology, a window actually is what we nowadays call a
+window, and :term:`views` (sometimes called frames) correspond to the content
+of a window.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -4,21 +4,20 @@ FAQ
 How do I run a new webmacs instance instead of a new buffer from the command-line?
 **********************************************************************************
 
-When there is already a webmacs instance running, calling `webmacs <url>` from a
-shell will open the url in a new buffer of the running instance. To run a fresh
+When a webmacs instance is already running, calling `webmacs <url>` from a
+shell will open the URL in a new buffer of the running instance. To run a fresh
 new instance, use `webmacs --instance <instance-unique-name> <url>`.
 
 
 Website is blocked, turn off the extensions
 *******************************************
 
-This message will appear in the browser when the url was filtered by the
+This message will appear in the browser when the URL has got filtered by the
 ad-blocker.
 
-You can temporarily disable the ad-blocker with *M-x toggle-ad-block* to
-overcome this.
+To overcome this, you can temporarily disable the ad-blocker with *M-x toggle-ad-block*.
 
 For a permanent change, edit the :var:`adblock-urls-rules` variable, to remove
-some urls in there. Note if you set this variable to an empty list, the
+some URLs in there. Note if you set this variable to an empty list, the
 adblocker will be completely disabled. See the :ref:`user_conf_variables`
 section in the documentation.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -7,7 +7,7 @@ Glossary
   web buffer
     The content of a web page, not including its window or view.
 
-    You can learn the basics of buffer handing in :ref:`managing_buffers`.
+    You can learn the basics of buffer handling in :ref:`managing_buffers`.
 
   command
   commands
@@ -15,12 +15,12 @@ Glossary
 
     See :ref:`concept_commands` for a detailed description.
 
-    See :ref:`Commands <user_conf_commands>` for a list of commands, or better
+    See :ref:`Commands <user_conf_commands>` for a list of commands; or better,
     use the :cmd:`describe-commands` command to get live documentation.
 
   hinting
-   hinting is used to navigate through visible links and objects of the current
-   web buffer's page using the keyboard only.
+   Hinting is used to navigate through the visible links and objects of the
+   current web buffer's page, using the keyboard only.
 
    See :ref:`link_hinting` for more information.
 
@@ -38,19 +38,20 @@ Glossary
 
     See :ref:`concept_commands` for a detailed description.
 
-    See :ref:`Keymaps <user_conf_keymaps>` for a list of keymaps, or better use
+    See :ref:`Keymaps <user_conf_keymaps>` for a list of keymaps; or better, use
     the :cmd:`describe-bindings` command to get live documentation.
 
   minibuffer
     The minibuffer is what can be seen at the bottom of a webmacs window. It
-    displays some information on the right, like the currently active keymap and
-    the number of opened buffers.
+    displays some information on the right, such as the currently active keymap
+    and the number of open buffers.
 
   minibuffer input
-    When webmacs is waiting some information from you, the **minibuffer input**
-    is shown: it's a text edit field in which you can type some text.
+    When webmacs is waiting for some information from you, the
+    **minibuffer input** is shown: it's a text edit field in which you can type
+    some text.
 
-    Often there also is a completion list above the minibuffer input.
+    Often, there also is a completion list above the minibuffer input.
 
   variable
   variables
@@ -58,8 +59,8 @@ Glossary
 
     See :ref:`user_conf_variables` for variables configuration.
 
-    See :ref:`All variables <user_conf_all_variables>` to see all the variables,
-    or better use :cmd:`describe-variables` to get live documentation.
+    See :ref:`All variables <user_conf_all_variables>` to see all the variables;
+    or better, use :cmd:`describe-variables` to get live documentation.
 
   view
   views
@@ -70,10 +71,10 @@ Glossary
 
   webjump
   webjumps
-    A Webjump represents a quick way to access an url, possibly with a variable
+    A Webjump represents a quick way to access a URL, possibly with a variable
     part. A webjump name becomes a part of the webmacs :cmd:`go-to` command, so
-    for example you can type ``google foo bar`` to execute a google query with
+    for example you can type ``google foo bar`` to execute a Google query with
     "foo bar" terms.
 
     See :ref:`user_conf_webjumps` to see the builtins webjumps and how to
-    configure you owns.
+    configure your owns.

--- a/docs/user_configuration.rst
+++ b/docs/user_configuration.rst
@@ -1,26 +1,26 @@
 User configuration
 ==================
 
-**webmacs** can be configured by writing Python code. The files should lives in
+**webmacs** can be configured by writing Python code. The files should live in
 a ``~/.webmacs/init`` directory, starting with an ``__init__.py`` file.
 
 If this file exists, it will be loaded early in the application.
 
-Note you have the full power of Python in there, and as it is loaded early you
-can change and adapt nearly everything of the webmacs behavior.
+Note that you have the full power of Python in there, and as it is loaded early,
+you can change and adapt nearly every aspect of the webmacs behavior.
 
 .. note::
 
    Only the documented functions and objects here are considered stable (meaning
-   it won't change without change notes and explanations). The other api you can
-   use is considered internal and might change without notification.
+   they will not change without change notes and explanations). Any other API
+   you can use is considered internal and might change without notification.
 
 
 The init function
 *****************
 
 You can write a function **init** that would be called when webmacs is about to
-start. This function must takes one parameter (usually named *opts*), that
+start. This function must take one parameter (usually named *opts*), that
 contains the result of the parsed command line. For now, there is only one
 useful parameter:
 
@@ -42,8 +42,8 @@ example:
        webmacs.main.init(opts)
 
 
-The default webmacs.main.init function is responsible restoring the session, or
-opening the given url for example.
+The default webmacs.main.init function is responsible for restoring the session,
+or opening the given URL, for example.
 
 
 .. note::
@@ -58,7 +58,7 @@ Using more than one configuration file
 **************************************
 
 It is possible to write more than one configuration file. The
-directory where the ``__init__.py`` file lives is a python package, so
+directory where the ``__init__.py`` file lives is a Python package, so
 it is possible to just use relative imports.
 
 For example:
@@ -103,7 +103,7 @@ Modes
 *****
 
 Modes are used to bind keymaps to a web buffer, by assigning the buffer a given
-mode. By default all buffers are using the "standard-mode".
+mode. By default, all buffers use the "standard-mode".
 
 Here is the list of the pre-defined modes:
 
@@ -128,7 +128,7 @@ Example:
 Binding keys
 ************
 
-In webmacs, like in emacs, it is possible to bind a key to command on a given
+In webmacs, like in Emacs, it is possible to bind a key to a command on a given
 keymap.
 
 .. _user_conf_keymaps:
@@ -136,8 +136,9 @@ keymap.
 Keymaps
 -------
 
-Here is the list of available keymaps. Note you can see them live (with their
-associated key bindings) in webmacs by running the command `describe-bindings`.
+Here is the list of available keymaps. Note that you can see them live (with
+their associated key bindings) in webmacs by running the command
+`describe-bindings`.
 
 .. webmacs-keymaps::
 
@@ -177,7 +178,7 @@ You should use :meth:`webmacs.keymaps.Keymap.define_key`. Here is an example:
 .. note::
 
    The global buffer should not define single letter keychords, as you
-   won't be able to type that letter in editable fields, thus this is
+   won't be able to type that letter in editable fields; though, this is
    possible in the webbuffer :term:`keymap`.
 
 .. _user_conf_webjumps:
@@ -201,6 +202,6 @@ You can implement your own webjumps, or override the existing
 ones. See :func:`webmacs.commands.webjump.define_webjump` and the
 example above.
 
-By default in webmacs, pressing the ``s`` key will call the command
-``search-default``, wich will use the duckduckgo webjump. To change
-that default, change the value of the variable *webjump-default*.
+Pressing the ``s`` key will call the command
+``search-default``, wich will, by default, use the Google webjump. To change
+this default, change the value of the variable *webjump-default*.

--- a/webmacs/commands/caret_browsing.py
+++ b/webmacs/commands/caret_browsing.py
@@ -57,7 +57,7 @@ def up(ctx):
 @define_command("caret-browsing-backward-char")
 def left_char(ctx):
     """
-    Move the caret to one character backward.
+    Move the caret one character backward.
     """
     call_js(ctx, "CaretBrowsing.move('backward', 'character');")
 
@@ -65,7 +65,7 @@ def left_char(ctx):
 @define_command("caret-browsing-backward-word")
 def left_word(ctx):
     """
-    Move the caret to one word backward.
+    Move the caret one word backward.
     """
     call_js(ctx, "CaretBrowsing.move('backward', 'word');")
 
@@ -73,7 +73,7 @@ def left_word(ctx):
 @define_command("caret-browsing-forward-char")
 def right_char(ctx):
     """
-    Move the caret to one character forward.
+    Move the caret one character forward.
     """
     call_js(ctx, "CaretBrowsing.move('forward', 'character');")
 
@@ -81,7 +81,7 @@ def right_char(ctx):
 @define_command("caret-browsing-forward-word")
 def right_word(ctx):
     """
-    Move the caret to one word forward.
+    Move the caret one word forward.
     """
     call_js(ctx, "CaretBrowsing.move('forward', 'word');")
 

--- a/webmacs/commands/content_edit.py
+++ b/webmacs/commands/content_edit.py
@@ -48,7 +48,7 @@ def run_js(ctx, cmd, cb=None):
 def cancel(ctx):
     """
     If a mark is active, clear that but keep the focus. If there is no
-    mark active, then just unfocus the editable js object.
+    active mark, then just unfocus the editable js object.
     """
     if ctx.buffer.hasSelection():
         run_js(ctx, "textedit.clear_mark();")
@@ -163,7 +163,7 @@ def delete_word_backward(ctx):
 @define_command("content-edit-copy")
 def copy(ctx):
     """
-    Copy browser text field selection in the clipboard.
+    Copy browser text field selection to the clipboard.
     """
     ctx.buffer.set_text_edit_mark(False)
     run_js(ctx, "textedit.copy_text(true);")
@@ -172,7 +172,7 @@ def copy(ctx):
 @define_command("content-edit-cut")
 def cut(ctx):
     """
-    Cut browser text field selection in the clipboard.
+    Cut browser text field selection to the clipboard.
     """
     run_js(ctx, "textedit.copy_text();",
            delete_selection(ctx))

--- a/webmacs/commands/follow.py
+++ b/webmacs/commands/follow.py
@@ -42,7 +42,7 @@ hint_alphabet_characters = variables.define_variable(
 
 hint_node_style = variables.define_variable(
     "hint-node-style",
-    "The style to apply to the hint div. Note that it is a dict of javascript"
+    "The style to apply to the hint div. Note that it is a dict of JavaScript"
     " style property names to values. See"
     " https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style.",
     {
@@ -152,7 +152,7 @@ class HintPrompt(Prompt):
                         Qt.Key_Meta,
                         Qt.Key_unknown,
                         Qt.Key_Return,
-                        ):
+                ):
                     self.numbers = ""
                     self._update_label()
             elif self.method == "alphabet":

--- a/webmacs/commands/global.py
+++ b/webmacs/commands/global.py
@@ -119,7 +119,7 @@ def _get_or_create_buffer(win):
 @define_command("split-view-right")
 def split_window_right(ctx):
     """
-    Create a new view on right of the current one.
+    Create a new view on the right of the current one.
     """
     win = ctx.window
     view = win.create_webview_on_right()
@@ -218,7 +218,7 @@ def maximise_view(ctx):
 @define_command("toggle-ad-block")
 def toggle_ad_block(ctx):
     """
-    Toggle ad blocking on or off.
+    Toggle ad-blocking on or off.
     """
     from .webbuffer import reload_buffer_no_cache
 
@@ -235,6 +235,7 @@ def toggle_toolbar(ctx):
 
 
 class VisitedLinksModel(PromptTableModel):
+
     def __init__(self, parent):
         visitedlinks = app().visitedlinks()
         PromptTableModel.__init__(self, visitedlinks.visited_urls())
@@ -301,6 +302,7 @@ def visited_links_history(ctx):
 
 
 class BookmarksModel(VisitedLinksModel):
+
     def __init__(self, parent):
         bookmarks = app().bookmarks()
         PromptTableModel.__init__(self, bookmarks.list())
@@ -498,6 +500,7 @@ def describe_command(ctx):
 
 
 class ReportCallHandler(CallHandler):
+
     def __init__(self, prompt):
         CallHandler.__init__(self)
         self.prompt = prompt

--- a/webmacs/commands/webbuffer.py
+++ b/webmacs/commands/webbuffer.py
@@ -40,6 +40,7 @@ switch_buffer_current_color = variables.define_variable(
 
 
 class BufferTableModel(QAbstractTableModel):
+
     def __init__(self, buffers):
         QAbstractTableModel.__init__(self)
         self._buffers = list(buffers)
@@ -129,6 +130,7 @@ class BufferListPrompt(Prompt):
 
 
 class RecentBufferListPrompt(BufferListPrompt):
+
     def ordered_buffers(self):
         return recent_buffers()
 
@@ -453,8 +455,8 @@ def buffer_escape(ctx):
     """
     Clear selection or menus in the current buffer.
 
-    The implementation clear the selection in the buffer if there is any, else
-    it sends the Escape key which usually close whatever takes the focus.
+    The implementation clears the selection in the buffer if there is any, else
+    it sends the Escape key which usually closes whatever takes the focus.
     """
     if ctx.buffer.hasSelection():
         buffer_unselect(ctx)
@@ -463,6 +465,7 @@ def buffer_escape(ctx):
 
 
 class KilledBufferTableModel(QAbstractTableModel):
+
     def __init__(self):
         QAbstractTableModel.__init__(self)
         self._buffers = list(KilledBuffer.all)
@@ -526,7 +529,7 @@ def revive_buffer(ctx):
 @define_command("copy-current-link")
 def copy_current_link(ctx):
     """
-    Copy the current link in the clipboard.
+    Copy the current link to the clipboard.
     """
 
     # note the implementation does not rely on the CopyLinkToClipboard action
@@ -552,7 +555,7 @@ def copy_current_link(ctx):
 @define_command("copy-current-buffer-url")
 def copy_buffer_url(ctx):
     """
-    Copy the url of the current buffer to the clipboard.
+    Copy the URL of the current buffer to the clipboard.
     """
     url = str(ctx.buffer.url().toEncoded(), "utf-8")
     app().clipboard().setText(url)

--- a/webmacs/commands/webjump.py
+++ b/webmacs/commands/webjump.py
@@ -152,7 +152,8 @@ class WebJumpRequestCompleter(WebJumpCompleter):
         URL that will provide completion. The returned value can be none
         if no URL is suitable for the given text.
     :param extract_completions_fn: a function that takes the bytes of the
-        request reply, and must convert them to the completions (a string list).
+        request reply, and must convert them to the completions
+        (a string list).
     """
 
     def __init__(self, url_fn, extract_completions_fn):

--- a/webmacs/commands/webjump.py
+++ b/webmacs/commands/webjump.py
@@ -48,13 +48,13 @@ def define_webjump(name, url, doc="", complete_fn=None, protocol=False):
     """
     Define a webjump.
 
-    A webjump is a quick way to access an url, optionally with a
-    variable section (for example an url for a google search). A
-    function might be given to provide auto-completion.
+    A webjump is a quick way to access a URL, optionally with a
+    variable section (for example a URL for a Google search). A
+    function may be given to provide auto-completion.
 
     :param name: the name of the webjump.
     :param url: the url of the webjump. If the url contains "%s", it is
-        assumed that it as a variable part.
+        assumed that it has a variable part.
     :param doc: associated documentation for the webjump.
     :param complete_fn: a function that should create a suitable
         :class:`WebJumpCompleter` to provide auto-completion, or None if there
@@ -74,7 +74,7 @@ def define_webjump(name, url, doc="", complete_fn=None, protocol=False):
 
 
 def define_protocol(name, doc="", complete_fn=None):
-    define_webjump(name, name+"://%s", doc, complete_fn, True)
+    define_webjump(name, name + "://%s", doc, complete_fn, True)
 
 
 def set_default(name):
@@ -89,6 +89,7 @@ def set_default(name):
 
 
 class WebJumpCompleter(QObject):
+
     """
     Provides auto-completion in webjumps.
 
@@ -97,10 +98,10 @@ class WebJumpCompleter(QObject):
     method :meth:`complete` is called with the current text, asking for
     completion.
 
-    The signal `completed` must be then be emitted with the list of possible
+    The signal `completed` must then be emitted with the list of possible
     completions.
 
-    Note there is no underlying thread in the completion framework.
+    Note that there is no underlying thread in the completion framework.
     """
     completed = Signal(list)
 
@@ -118,14 +119,16 @@ class WebJumpCompleter(QObject):
 
 
 class SyncWebJumpCompleter(WebJumpCompleter):
+
     """
     A simple completer that provides completion given a function.
 
-    This completer will block the ui, use it with care.
+    This completer will block the UI: use it with care.
 
     :param complete_fn: a function that takes the current string, and must
-        returns the possible completions as a list of strings.
+        return the possible completions as a list of strings.
     """
+
     def __init__(self, complete_fn):
         WebJumpCompleter.__init__(self)
         self.complete_fn = complete_fn
@@ -139,17 +142,19 @@ def empty_completer():
 
 
 class WebJumpRequestCompleter(WebJumpCompleter):
+
     """
-    A completer that execute a web request to provide completion.
+    A completer that executes a Web request to provide completion.
 
-    This completer will not block the ui.
+    This completer will not block the UI.
 
-    :param url_fn: a function that takes the text to complete, and returns an
-        url that will provide completion. The returns can be none if no url is
-        suitable for the given text.
+    :param url_fn: a function that takes the text to complete, and returns a
+        URL that will provide completion. The returned value can be none
+        if no URL is suitable for the given text.
     :param extract_completions_fn: a function that takes the bytes of the
-        request reply, and must convert it to the completions (a string list).
+        request reply, and must convert them to the completions (a string list).
     """
+
     def __init__(self, url_fn, extract_completions_fn):
         WebJumpCompleter.__init__(self)
         self.url_fn = url_fn
@@ -281,7 +286,7 @@ class WebJumpPrompt(Prompt):
                 m_input.popup().selectionModel()\
                                .selectionChanged.connect(
                                    self._popup_selection_changed
-                               )
+                )
 
     def _popup_selection_changed(self, _sel, _desel):
         # try to abort any completion if the user select something in
@@ -349,6 +354,7 @@ class WebJumpPrompt(Prompt):
 
 
 class WebJumpPromptAlternateUrl(WebJumpPrompt):
+
     def enable(self, minibuffer):
         WebJumpPrompt.enable(self, minibuffer)
         minibuffer.input().deselect()
@@ -431,7 +437,7 @@ def get_url(prompt):
 @define_command("go-to", prompt=WebJumpPrompt)
 def go_to(ctx):
     """
-    Prompt to open an url or a webjump.
+    Prompt to open a URL or a webjump.
     """
     url = get_url(ctx.prompt)
     if url:
@@ -441,7 +447,7 @@ def go_to(ctx):
 @define_command("go-to-alternate-url", prompt=WebJumpPromptAlternateUrl)
 def go_to_selected_url(ctx):
     """
-    Prompt to open an alternative url from the current one.
+    Prompt to open an alternative URL from the current one.
     """
     go_to(ctx)
 
@@ -453,7 +459,7 @@ class WebJumpPromptNewUrl(WebJumpPrompt):
 @define_command("go-to-new-buffer", prompt=WebJumpPromptNewUrl)
 def go_to_new_buffer(ctx):
     """
-    Prompt to open an url or webjump in a new buffer.
+    Prompt to open a URL or webjump in a new buffer.
     """
     go_to(ctx)
 
@@ -468,7 +474,7 @@ class WebJumpPromptAlternateUrlNewBuffer(WebJumpPromptAlternateUrl):
 )
 def go_to_selected_url_new_buffer(ctx):
     """
-    Prompt to open an alternative url from the current one in a new buffer.
+    Prompt to open an alternative URL from the current one in a new buffer.
     """
     go_to(ctx)
 
@@ -476,7 +482,7 @@ def go_to_selected_url_new_buffer(ctx):
 @define_command("search-default", prompt=DefaultSearchPrompt)
 def search_default(ctx):
     """
-    Prompt to open an url with the default webjump.
+    Prompt to open a URL with the default webjump.
     """
     go_to(ctx)
 
@@ -489,6 +495,6 @@ class DefaultSearchPromptNewBuffer(DefaultSearchPrompt):
     "search-default-new-buffer", prompt=DefaultSearchPromptNewBuffer)
 def search_default_new_buffer(ctx):
     """
-    Prompt to open an url with the default webjump.
+    Prompt to open a URL with the default webjump.
     """
     go_to_new_buffer(ctx)

--- a/webmacs/main.py
+++ b/webmacs/main.py
@@ -40,7 +40,7 @@ log_to_disk = variables.define_variable(
 
 def signal_wakeup(app):
     """
-    Allow to be notified in python for signals when in long-running calls from
+    Allow to be notified in Python for signals when in long-running calls from
     the C or c++ side, like QApplication.exec_().
 
     See https://stackoverflow.com/a/37229299.
@@ -87,6 +87,7 @@ def setup_logging_on_disk(log_dir, backup_count=5):
     webcontent = logging.getLogger("webcontent")
 
     class Formatter(logging.Formatter):
+
         def formatMessage(self, record):
             fmt = ("%(levelname)s %(name)s: [%(url)s] %(message)s"
                    if record.name == "webcontent"
@@ -115,9 +116,9 @@ def parse_args(argv=None):
                         choices=("debug", "info", "warning",
                                  "error", "critical"))
 
-    # There is no such javascript error level, critical - still since there
-    # is some logs that are printed anyway and that it is easier to implement
-    # let's keep the critical level.
+    # There is no such JavaScript error level, critical - still since there
+    # are some logs that are printed anyway and that it is easier to implement.
+    # Let's keep the critical level.
     parser.add_argument("-w", "--webcontent-log-level",
                         help="Set the log level for the web contents,"
                         " defaults to %(default)s.",
@@ -144,7 +145,7 @@ def init(opts):
     """
     Default initialization of webmacs.
 
-    If an url is given on the command line, it opens it. Else it try
+    If a URL is given on the command line, this method opens it. Else, it tries
     to load the buffers that were opened the last time webmacs has
     exited. If none of that works, the default is to open a buffer
     with an url to the duckduck go search engine.


### PR DESCRIPTION
Hello.

Here are a few minor suggestions for improving the documentation.
The documentation is globally very well written; I have only added minor syntax corrections (mainly added or removed 's' occurrences), and capitalizations (emacs -> Emacs ; javascript -> JavaScript; an url -> a URL).  Lastly, a few linguistic changes which, I suppose, are debatable; feel free to integrate them or not, I will be happy to discuss them.

I hope the changes do not break anything; I have been unable to regenerate the documentation (on Debian stable).

```
cd docs
make html
Running Sphinx v1.4.9

Extension error:
Could not import extension webmacs_sphinx_ext (exception: No module named '_adblock')
Makefile:20: recipe for target 'html' failed
make: *** [html] Error 1
```
