### PR TITLE
Add function: define_webjump_alias

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,6 +29,7 @@ Webjumps
 
 .. autoclass:: webmacs.commands.webjump.SyncWebJumpCompleter
 
+.. autofunction:: webmacs.commands.webjump.define_webjump_alias
 
 Variables
 *********

--- a/docs/user_configuration.rst
+++ b/docs/user_configuration.rst
@@ -205,3 +205,12 @@ example above.
 Pressing the ``s`` key will call the command
 ``search-default``, wich will, by default, use the Google webjump. To change
 this default, change the value of the variable *webjump-default*.
+
+It is also possible to define an alias to an existing webjump,
+without duplicating its implementation.
+
+.. code-block:: python
+
+   from webmacs.commands.webjump import define_webjump_alias
+
+   define_webjump_alias("g", "google")

--- a/webmacs/commands/webjump.py
+++ b/webmacs/commands/webjump.py
@@ -73,6 +73,18 @@ def define_webjump(name, url, doc="", complete_fn=None, protocol=False):
     )
 
 
+def define_webjump_alias(alias_name, webjump_name):
+    """
+    Define an alias for an existing webjump.
+
+    The alias can then be used as a shortcut.
+    :param alias_name: the name of the alias to be created.
+    :param webjump_name: the name of the existing webjump.
+
+    """
+    WEBJUMPS[alias_name.strip()] = WEBJUMPS[webjump_name]
+
+
 def define_protocol(name, doc="", complete_fn=None):
     define_webjump(name, name + "://%s", doc, complete_fn, True)
 


### PR DESCRIPTION
Hello.

I found it helpful to add this simple function for defining an alias to a webjump (and avoid duplicating its completer, URL, ...).
usage:
define_webjump_alias("g", "google")

Would you think it worthwhile to include it to webmacs (if so, I will also add some documentation)? Or should I define it somewhere in my customization files? 

Thanks for attention.
