### PR TITLE
append suggested name when the download path is a directory

### DIFF
--- a/webmacs/download_manager/__init__.py
+++ b/webmacs/download_manager/__init__.py
@@ -196,8 +196,8 @@ class DownloadManager(QObject):
         elif action == "download":
             path = dl.path()
             user_dir = get_user_download_dir()
+            _, name = extract_suggested_filename(path)
             if user_dir is not None:
-                _, name = extract_suggested_filename(path)
                 try:
                     path = find_unique_suggested_path(user_dir, name)
                 except OSError as exc:
@@ -210,6 +210,9 @@ class DownloadManager(QObject):
             if path is None:
                 return
 
+            if os.path.isdir(path):
+                path = find_unique_suggested_path(path, name)
+            
             if os.path.isfile(path):
                 if not minibuff.do_prompt(OverwriteFilePrompt(path)):
                     return

--- a/webmacs/download_manager/__init__.py
+++ b/webmacs/download_manager/__init__.py
@@ -212,7 +212,7 @@ class DownloadManager(QObject):
 
             if os.path.isdir(path):
                 path = find_unique_suggested_path(path, name)
-            
+
             if os.path.isfile(path):
                 if not minibuff.do_prompt(OverwriteFilePrompt(path)):
                     return


### PR DESCRIPTION
At the moment setting a directory as download path results in the file not beeing downloaded at all.
This PR changes this to automatically append the suggested name.
I think this is the behaviour everyone would expect when setting a directory as download path.
