### PR TITLE
Make bookmark name default to webpage title

### DIFF
--- a/webmacs/commands/global.py
+++ b/webmacs/commands/global.py
@@ -330,6 +330,17 @@ class BookmarkAddPrompt(Prompt):
         input.setSelection(0, len(url))
 
 
+class BookmarkNamePrompt(Prompt):
+    label = "bookmark's name: "
+
+    def enable(self, minibuffer):
+        Prompt.enable(self, minibuffer)
+        name = self.ctx.buffer.title()
+        input = minibuffer.input()
+        input.setText(name)
+        input.setSelection(0, len(name))
+
+
 @define_command("bookmark-add")
 def bookmark_add(ctx):
     """
@@ -340,8 +351,7 @@ def bookmark_add(ctx):
     if not url:
         return
 
-    otherprompt = Prompt(ctx)
-    otherprompt.label = "bookmark's name: "
+    otherprompt = BookmarkNamePrompt(ctx)
     name = ctx.minibuffer.do_prompt(otherprompt)
 
     if name:


### PR DESCRIPTION
What it says on the tin. Usually I want to name my bookmarks the same as the title of the webpage. This also mirrors conkeror behavior.

It should be noted that I sense some refactoring potential here when it comes to prompt objects that start out with a pre-filled value selected/not selected, but I elected not to spend more time on this for the time being, and instead get a discussion going.