### PR TITLE
new-window flag to open window in existing instance.

### DIFF
--- a/webmacs/commands/global.py
+++ b/webmacs/commands/global.py
@@ -26,7 +26,7 @@ from ..webbuffer import create_buffer, get_or_create_buffer
 from ..keymaps import KeyPress, VISITEDLINKS_KEYMAP, BOOKMARKS_KEYMAP
 from ..keyboardhandler import send_key_event, local_keymap, KEY_EATER, \
     CallHandler
-from .. import BUFFERS, windows, variables
+from .. import windows, variables
 from ..mode import MODES
 from ..window import Window
 from ..session import session_clean, session_load

--- a/webmacs/commands/global.py
+++ b/webmacs/commands/global.py
@@ -1,3 +1,4 @@
+
 # This file is part of webmacs.
 #
 # webmacs is free software: you can redistribute it and/or modify
@@ -21,7 +22,7 @@ from . import define_command, COMMANDS, register_prompt_opener_commands
 from ..minibuffer import Prompt
 from ..minibuffer.prompt import PromptTableModel, PromptHistory
 from ..application import app
-from ..webbuffer import create_buffer
+from ..webbuffer import create_buffer, get_or_create_buffer
 from ..keymaps import KeyPress, VISITEDLINKS_KEYMAP, BOOKMARKS_KEYMAP
 from ..keyboardhandler import send_key_event, local_keymap, KEY_EATER, \
     CallHandler
@@ -96,29 +97,6 @@ def toggle_maximised(ctx):
         win.showMaximized()
 
 
-def _get_or_create_buffer(win):
-    visible_buffers = []
-    for awin in windows():
-        for view in awin.webviews():
-            visible_buffers.append(view.buffer())
-    current_buffer = win.current_webview().buffer()
-    buffers = [b for b in BUFFERS
-               if b not in visible_buffers
-               or b == current_buffer]
-
-    # if there is at least one buffer not visible, use the one just
-    # after the current one in the list
-    if len(buffers) > 1:
-        ibuffers = itertools.cycle(buffers)
-        while True:
-            buff = next(ibuffers)
-            if buff == current_buffer:
-                return next(ibuffers)
-
-    # else create a new buffer, reusing the current buffer's url
-    return create_buffer(url=current_buffer.url())
-
-
 @define_command("split-view-right")
 def split_window_right(ctx):
     """
@@ -126,7 +104,7 @@ def split_window_right(ctx):
     """
     win = ctx.window
     view = win.create_webview_on_right()
-    view.setBuffer(_get_or_create_buffer(win))
+    view.setBuffer(get_or_create_buffer(win))
     view.set_current()
 
 
@@ -137,7 +115,7 @@ def split_window_bottom(ctx):
     """
     win = ctx.window
     view = win.create_webview_on_bottom()
-    view.setBuffer(_get_or_create_buffer(win))
+    view.setBuffer(get_or_create_buffer(win))
     view.set_current()
 
 
@@ -151,7 +129,7 @@ def create_window(ctx):
     win.current_webview().setBuffer(
         create_buffer(home_page)
         if home_page and variables.get("home-page-in-new-window")
-        else _get_or_create_buffer(ctx.window)
+        else get_or_create_buffer(ctx.window)
     )
     win.show()
     win.activateWindow()

--- a/webmacs/ipc.py
+++ b/webmacs/ipc.py
@@ -182,16 +182,16 @@ def ipc_dispatch(data):
 
     win = Window() if new_window else current_window()
 
-    if url:
-        view = win.current_webview()
-        view.setBuffer(create_buffer(url))
-
     if new_window:
         view = win.current_webview()
         if url:
             view.setBuffer(create_buffer(url))
         else:
             view.setBuffer(get_or_create_buffer(current_window()))
+
+    elif url:
+        view = win.current_webview()
+        view.setBuffer(create_buffer(url))
 
     # this is quite hard to raise a window. The following works fine
     # for me with gnome 3.

--- a/webmacs/ipc.py
+++ b/webmacs/ipc.py
@@ -21,7 +21,8 @@ from PyQt5.QtCore import QObject, pyqtSlot as Slot, pyqtSignal as Signal, Qt, \
     QDir
 from PyQt5.QtNetwork import QLocalServer, QLocalSocket
 from . import version
-
+from .window import Window
+from . import variables
 
 HEADER_FMT = "!I"
 HEADER_SIZE = struct.calcsize(HEADER_FMT)
@@ -176,8 +177,25 @@ class IpcServer(QObject):
 def ipc_dispatch(data):
     from . import current_window
     from .webbuffer import create_buffer
-    win = current_window()
+
     url = data.get("url")
+    new_window = data.get("new_window")
+
+    if new_window:
+        win = Window()
+        view = win.current_webview()
+        if url:
+            view.setBuffer(create_buffer(url))
+        else:
+            home_page = variables.get("home-page")
+            win.current_webview().setBuffer(
+                create_buffer(home_page))
+        win.show()
+        win.activateWindow()
+        return
+
+    win = current_window()
+
     if url:
         view = win.current_webview()
         view.setBuffer(create_buffer(url))

--- a/webmacs/ipc.py
+++ b/webmacs/ipc.py
@@ -22,7 +22,6 @@ from PyQt5.QtCore import QObject, pyqtSlot as Slot, pyqtSignal as Signal, Qt, \
 from PyQt5.QtNetwork import QLocalServer, QLocalSocket
 from . import version
 from .window import Window
-from . import variables
 
 HEADER_FMT = "!I"
 HEADER_SIZE = struct.calcsize(HEADER_FMT)

--- a/webmacs/ipc.py
+++ b/webmacs/ipc.py
@@ -176,29 +176,20 @@ class IpcServer(QObject):
 
 def ipc_dispatch(data):
     from . import current_window
-    from .webbuffer import create_buffer
+    from .webbuffer import create_buffer, get_or_create_buffer
 
     url = data.get("url")
     new_window = data.get("new_window")
 
-    if new_window:
-        win = Window()
-        view = win.current_webview()
-        if url:
-            view.setBuffer(create_buffer(url))
-        else:
-            home_page = variables.get("home-page")
-            win.current_webview().setBuffer(
-                create_buffer(home_page))
-        win.show()
-        win.activateWindow()
-        return
-
-    win = current_window()
+    win = Window() if new_window else current_window()
 
     if url:
         view = win.current_webview()
         view.setBuffer(create_buffer(url))
+
+    if new_window:
+        view = win.current_webview()
+        view.setBuffer(get_or_create_buffer(current_window()))
 
     # this is quite hard to raise a window. The following works fine
     # for me with gnome 3.

--- a/webmacs/ipc.py
+++ b/webmacs/ipc.py
@@ -188,7 +188,10 @@ def ipc_dispatch(data):
 
     if new_window:
         view = win.current_webview()
-        view.setBuffer(get_or_create_buffer(current_window()))
+        if url:
+            view.setBuffer(create_buffer(url))
+        else:
+            view.setBuffer(get_or_create_buffer(current_window()))
 
     # this is quite hard to raise a window. The following works fine
     # for me with gnome 3.

--- a/webmacs/main.py
+++ b/webmacs/main.py
@@ -136,6 +136,10 @@ def parse_args(argv=None):
     parser.add_argument("url", nargs="?",
                         help="url to open")
 
+    parser.add_argument("--new-window", action="store_true",
+                        help="Creates a new window in the instance given."
+                        " If no instance is given, the default will be used.")
+
     opts = parser.parse_args(argv)
 
     # handle local file path


### PR DESCRIPTION
I've added functionality for calling `--new-window` to open a new window in an existing instance. I'd like to add the same functionality from commands/global.py with the _get_or_create_buffer function, however since the file is global.py in conflicts with built in `global` and I can't import it. I don't want to duplicate any code obviously. Any suggestions for how to resolve this? Maybe global.py should be renamed in the codebase? @parkouss 