### PR TITLE
Start webmacs with the --profile option 

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -9,6 +9,13 @@ shell will open the URL in a new buffer of the running instance. To run a fresh
 new instance, use `webmacs --instance <instance-unique-name> <url>`.
 
 
+How do I run webmacs with a specific profile from the command-line?
+**********************************************************************************
+To have webmacs use a specific profile, use
+`webmacs --profile <profile-name> <url>`. Each profile directory will contain
+distinct navigation data (history, cookies, ...).
+
+
 Website is blocked, turn off the extensions
 *******************************************
 

--- a/webmacs/application.py
+++ b/webmacs/application.py
@@ -28,7 +28,7 @@ from . import require
 from . import version
 from .adblock import Adblocker, AdblockUpdateRunner, adblock_urls_rules
 from .download_manager import DownloadManager
-from .profile import default_profile
+from .profile import named_profile
 from .minibuffer.right_label import init_minibuffer_right_labels
 from .keyboardhandler import LOCAL_KEYMAP_SETTER
 from .spell_checking import SpellCheckingUpdateRunner, \
@@ -116,7 +116,7 @@ def _app_requires():
 class Application(QApplication):
     INSTANCE = None
 
-    def __init__(self, conf_path, args, instance_name="default"):
+    def __init__(self, conf_path, args, instance_name="default", profile_name="default"):
         QApplication.__init__(self, args)
         self.__class__.INSTANCE = self
         self.instance_name = instance_name
@@ -146,7 +146,7 @@ class Application(QApplication):
 
         self._download_manager = DownloadManager(self)
 
-        self.profile = default_profile()
+        self.profile = named_profile(profile_name)
         self.profile.enable(self)
 
         settings = QWebEngineSettings.globalSettings()

--- a/webmacs/application.py
+++ b/webmacs/application.py
@@ -116,7 +116,8 @@ def _app_requires():
 class Application(QApplication):
     INSTANCE = None
 
-    def __init__(self, conf_path, args, instance_name="default", profile_name="default"):
+    def __init__(self, conf_path, args, instance_name="default",
+                 profile_name="default"):
         QApplication.__init__(self, args)
         self.__class__.INSTANCE = self
         self.instance_name = instance_name

--- a/webmacs/main.py
+++ b/webmacs/main.py
@@ -132,7 +132,8 @@ def parse_args(argv=None):
 
     parser.add_argument("-p", "--profile", default="default",
                         help="Use the named profile directory."
-                        " The profile directory will contain a separate history.")
+                        " Each profile will contain distinct navigation data"
+                        " (history, cookies, ...).")
 
     parser.add_argument("--list-instances", action="store_true",
                         help="List running instances and exit.")

--- a/webmacs/main.py
+++ b/webmacs/main.py
@@ -130,6 +130,10 @@ def parse_args(argv=None):
                         " If the given instance name is the empty string, an"
                         " automatically generated name will be used.")
 
+    parser.add_argument("-p", "--profile", default="default",
+                        help="Use the named profile directory."
+                        " The profile directory will contain a separate history.")
+
     parser.add_argument("--list-instances", action="store_true",
                         help="List running instances and exit.")
 
@@ -276,7 +280,7 @@ def main():
         # the x11 property WM_CLASS.
         "webmacs" if opts.instance == "default"
         else "webmacs-%s" % opts.instance
-    ], instance_name=opts.instance)
+    ], instance_name=opts.instance, profile_name=opts.profile)
     server = IpcServer(opts.instance)
     atexit.register(server.cleanup)
 

--- a/webmacs/profile.py
+++ b/webmacs/profile.py
@@ -128,5 +128,5 @@ class Profile(object):
         inject_js(os.path.join(THIS_DIR, "scripts", "autofill.js"))
 
 
-def default_profile():
-    return Profile("default")
+def named_profile(name):
+    return Profile(name)


### PR DESCRIPTION
These changes enable to start webmacs with the --profile option. Not a big change (since all the functionality was already there, just not activated), but I will take any remarks. Useful for these who like to have several browsers with distinct navigation data?

I have manually tested it to work as intended. Not sure how a unit test would fit in, however.