### PR TITLE
handle address query as search if it contains space

### DIFF
--- a/webmacs/commands/webjump.py
+++ b/webmacs/commands/webjump.py
@@ -43,6 +43,12 @@ webjump_default = variables.define_variable(
     type=variables.String(choices=WEBJUMPS),
 )
 
+webjump_use_default_for_query_with_spaces = variables.define_variable(
+    "webjump-use-default-query-on-spaces",
+    "Should default webjump be used to handle query with spaces?",
+    False,
+    type=variables.Bool(),
+)
 
 def define_webjump(name, url, doc="", complete_fn=None, protocol=False):
     """
@@ -392,6 +398,11 @@ class WebJumpPrompt(Prompt):
             candidates = [wj for wj in WEBJUMPS if wj.startswith(command)]
             if len(candidates) == 1:
                 webjump = WEBJUMPS[candidates[0]]
+
+        if (webjump_use_default_for_query_with_spaces.value and
+                webjump is None and " " in value):
+            webjump = WEBJUMPS.get(webjump_default.value)
+            args = [webjump_default.value, " ".join(args)]
 
         if webjump:
             if not webjump.allow_args:


### PR DESCRIPTION
When the entered address contains space, we can be rather certain that the content is not URL but webjump.

Let's add option which automatically use default webjump to handle the query.

1) I'm aware that the naming is not stellar.
2) I was considering more options how to get the same functionality but I'd need to duplicate WebJumpPrompt.value in some inherited class and monkey-patch `wj_prompt()`